### PR TITLE
Replace after by cleanup

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,19 +8,19 @@ provisioner:
 platforms:
 - name: centos-6.7
   provisioner:
-    require_chef_omnibus: 12.5.1
+    require_chef_omnibus: 12.8.1
   driver_config:
     box:     opscode-centos-6.7
 
 - name: centos-7.2
   provisioner:
-    require_chef_omnibus: 12.5.1
+    require_chef_omnibus: 12.8.1
   driver_config:
     box:     criteo-centos-7.2-core
 
 - name: windows-2012r2
   provisioner:
-    require_chef_omnibus: 12.5.1
+    require_chef_omnibus: 12.8.1
   driver_config:
     box: criteo-windows-2012r2-standard
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ choregraphie is French for choreography.
 Concepts
 --------
 
-A **choregraphie** describes actions which operate on some chef events. It allows, for instance, to run an action before and after the convergence of a resource.
+A **choregraphie** describes actions which operate on some chef events. It allows, for instance, to run an action before and after the convergence of a resource (currently: after means at the end of a sucessful run).
 
 A **primitive** is a helper for common idioms in choregraphies. Examples: grabbing a lock, silencing the monitoring, executing a shell command.
 
@@ -33,3 +33,12 @@ Missing Primitives
 ------------------
 
 Write your own, it is easy.
+
+How to write a primitive
+------------------------
+
+You should have a look at the example primitives such as `check_file`.
+
+Primitives can implement two callbacks:
+- _before_ is the callback called before the start of choregraphie (usually before the convergence of a resource)
+- _cleanup_ is the callback called at the end of successful chef-client run. Cleanup is always called so primitives must be efficient and safe to run at the end of all chef-client runs (for instance cleaning a file only if exists).

--- a/libraries/primitive_check_file.rb
+++ b/libraries/primitive_check_file.rb
@@ -14,8 +14,8 @@ module Choregraphie
         sleep(@period) until ::File.exists?(@file_path)
       end
 
-      choregraphie.after do
-        ::FileUtils.rm(@file_path)
+      choregraphie.cleanup do
+        ::FileUtils.rm(@file_path) if File.exists?(@file_path)
       end
     end
   end

--- a/libraries/primitive_consul_lock.rb
+++ b/libraries/primitive_consul_lock.rb
@@ -1,5 +1,4 @@
 require_relative 'primitive'
-require 'diplomat'
 
 # This primitive is based on optimistic concurrency (using compare-and-swap) rather than consul sessions.
 # It allows to support the unavailability of the local consul agent (for reboot, reinstall, ...)
@@ -50,7 +49,7 @@ module Choregraphie
         wait_until(:enter) { semaphore.enter(@options[:id]) }
       end
 
-      choregraphie.after do
+      choregraphie.cleanup do
         wait_until(:exit) { semaphore.exit(@options[:id]) }
       end
     end
@@ -71,6 +70,7 @@ module Choregraphie
   class Semaphore
 
     def self.get_or_create(path, concurrency)
+      require 'diplomat'
       retry_left = 5
       value = begin
                 Diplomat::Kv.get(path, decode_values: true)

--- a/spec/unit/primitive_check_file_spec.rb
+++ b/spec/unit/primitive_check_file_spec.rb
@@ -11,8 +11,9 @@ describe Choregraphie::CheckFile do
     expect(File).to receive(:exists?).and_return(false, false, false, true)
     choregraphie.before.each { |block| block.call }
   end
-  it 'must clean the file after' do
+  it 'must clean the file in cleanup' do
+    expect(File).to receive(:exists?).and_return(true)
     expect(FileUtils).to receive(:rm).with('random')
-    choregraphie.after.each { |block| block.call }
+    choregraphie.cleanup.each { |block| block.call }
   end
 end

--- a/spec/unit/primitive_consul_lock_spec.rb
+++ b/spec/unit/primitive_consul_lock_spec.rb
@@ -35,7 +35,7 @@ describe Choregraphie::ConsulLock do
 
         expect(Semaphore).to receive(:get_or_create).and_return(*([failing_lock] * fails + [lock]))
 
-        choregraphie.after.each { |block| block.call }
+        choregraphie.cleanup.each { |block| block.call }
       end
     end
   end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -25,6 +25,7 @@ end
 
 test_simple_resource 'not_converging' do
   content 'not_converging'
+  only_if { false }
 end
 
 
@@ -39,7 +40,7 @@ choregraphie 'execute' do
     require 'fileutils'
     FileUtils.touch(::File.join('/tmp', filename))
   end
-  after do
-    Chef::Log.info("I am called after!")
+  cleanup do
+    Chef::Log.info("I am called at the end!")
   end
 end


### PR DESCRIPTION
In order to guarantee that "after" blocks are run, this patch replaces a
"after" block by "cleanup".
Cleanup is always launched at the end of the run, each primitive is
responsible to be efficient and to converge correctly.

Also make test pass (how could they pass before?)
