### PR TITLE
Add an example of custom resource using workaround for why-run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.2.0
+- 2.3.0
 deploy:
   edge:
     source: criteo-forks/dpl

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ gem 'kitchen-transport-speedy'
 group :ec2 do
   gem 'test-kitchen'
   gem 'kitchen-ec2', git: 'https://github.com/criteo-forks/kitchen-ec2.git', branch: 'criteo'
-  gem 'winrm',       '~> 1.6'
-  gem 'winrm-fs',    '~> 0.3'
+  gem 'winrm',       '>= 1.6'
+  gem 'winrm-fs',    '>= 0.3'
 end
 
 # Other gems should go after this comment

--- a/README.md
+++ b/README.md
@@ -7,14 +7,39 @@ choregraphie is French for choreography.
 Concepts
 --------
 
+A **protected resource** is a resource whose convergence can induce downtime on the service. For instance, `service[mydatabase]` is usually a resource to protect.
+
 A **choregraphie** describes actions which operate on some chef events. It allows, for instance, to run an action before and after the convergence of a resource (currently: after means at the end of a sucessful run).
 
 A **primitive** is a helper for common idioms in choregraphies. Examples: grabbing a lock, silencing the monitoring, executing a shell command.
+
+
+Example
+-------
+
+    choregraphie 'my elasticsearch' do
+      # protect against service and network restart
+      on 'service[mydatase]'
+      on 'service[network]'
+
+      # protect against all reboot resources
+      on /^reboot\[/
+
+      # built-in primitive
+      consul_lock(path: 'choregraphie/locks/myes', concurrency: 2)
+
+      before do
+        # roll your own code
+        downtime_in_monitoring
+      end
+    end
 
 Support
 -------
 
 Only chef >= 12.6 is supported (due to a dependency on :before notifications).
+
+Usage of compat\_resource cookbook is highly discouraged as it modifies chef behavior and has silently broken :before notification in the past which are the foundation of choregraphie. Branch 'criteo' in criteo-forks organization is a safely patched version of this cookbook to avoid any chef monkeypatching.
 
 Choregraphies can be applied only on resources that support whyrun (currently chef default resources and resource/provider style).
 Custom resources (the whole resource defined in the resources/ directory) are not supported at the moment.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Only chef >= 12.6 is supported (due to a dependency on :before notifications).
 Usage of compat\_resource cookbook is highly discouraged as it modifies chef behavior and has silently broken :before notification in the past which are the foundation of choregraphie. Branch 'criteo' in criteo-forks organization is a safely patched version of this cookbook to avoid any chef monkeypatching.
 
 Choregraphies can be applied only on resources that support whyrun (currently chef default resources and resource/provider style).
-Custom resources (the whole resource defined in the resources/ directory) are not supported at the moment.
+Custom resources (the whole resource defined in the resources/ directory) are not supported at the moment (see https://github.com/chef/chef/issues/4537 for a discussion).
 
 Available Primitives
 --------------------

--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -104,7 +104,7 @@ module Choregraphie
     def setup_hook(resource_name, opts)
 
       # catch before in the closure
-      before_events = before
+      before_events = method(:before)
 
       Chef.event_handler do
         on :converge_start do |run_context|
@@ -115,7 +115,7 @@ module Choregraphie
       ruby_block before_block_name(resource_name) do
         block do
           Chef::Log.debug "Resource #{resource_name} will converge"
-          before_events.each { |b| b.call(resource_name) }
+          before_events.call.each { |b| b.call(resource_name) }
         end
         action :nothing
         subscribes :create, resource_name, :before
@@ -137,7 +137,21 @@ module Choregraphie
           map(&:to_s).select { |resource_name| resource_name =~ event }.
           each { |resource_name| setup_hook(resource_name, opts) }
 
-        # TODO find a way to get resources defined after choregraphie
+        setup_hook = method(:setup_hook) # catches setup_hook in the closure
+        Chef.event_handler do
+          on :converge_start do |run_context|
+            fail "Resource name is nil!" unless event
+            run_context.resource_collection.
+              map(&:to_s).select { |resource_name| resource_name =~ event }.
+              each do |resource_name|
+                Chef::Log.warn "Will create a dynamic recipe for #{resource_name}"
+                Chef::Recipe.new(:choregraphie, "dynamic_resource_for_#{resource_name}", run_context).instance_eval do
+                  setup_hook.call(resource_name, opts)
+                end
+              end
+          end
+        end
+
       else
         #TODO
         raise "Symbol type is not yet supported"

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -13,6 +13,7 @@ describe 'test::default' do
         platform: 'centos',
         version:  '6.7'
       )
+      stub_command("test -f /tmp/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end
 
@@ -26,6 +27,7 @@ describe 'test::default' do
         platform: 'centos',
         version:  '7.2.1511'
       )
+      stub_command("test -f /tmp/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end
 
@@ -39,6 +41,7 @@ describe 'test::default' do
         platform: 'windows',
         version:  '2008R2'
       )
+      stub_command("test -f /tmp/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -36,11 +36,19 @@ end
 log "a_simple_log"
 log "another_log"
 
+custom_resource 'my converging custom resource'
+
+custom_resource 'my useless custom resource' do
+  only_if { false }
+end
+
 choregraphie 'execute' do
   on 'execute[converging]'
   on 'execute[not_converging]'
   on 'test_simple_resource[converging]'
   on 'test_simple_resource[not_converging]'
+  on 'custom_resource[my converging custom resource]'
+  on 'custom_resource[my useless custom resource]'
 
   on /^log\[/
 

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -54,3 +54,5 @@ choregraphie 'execute' do
     Chef::Log.warn('I am called at the end')
   end
 end
+
+log "a_log_defined_after_choregraphie"

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -7,6 +7,7 @@
 # Need to clean up in case of multiple convergence tests
 execute 'Clean up machine' do
   command "rm /tmp/not_converging.tmp"
+  only_if "test -f /tmp/not_converging.tmp"
 end
 
 # Using chef provided resource
@@ -32,12 +33,17 @@ test_simple_resource 'not_converging' do
   only_if { false }
 end
 
+log "a_simple_log"
+log "another_log"
 
 choregraphie 'execute' do
   on 'execute[converging]'
   on 'execute[not_converging]'
   on 'test_simple_resource[converging]'
   on 'test_simple_resource[not_converging]'
+
+  on /^log\[/
+
   before do |resource|
     Chef::Log.warn("I am called before! for resource " + resource.to_s)
     filename = resource.to_s.gsub(/\W+/, '_').gsub(/_$/,'')

--- a/test/cookbooks/test/resources/custom_resource.rb
+++ b/test/cookbooks/test/resources/custom_resource.rb
@@ -1,0 +1,16 @@
+# This custom resource explicitely supports whyrun using work-around described
+# on https://github.com/chef/chef/issues/4537
+
+resource_name :custom_resource
+
+provides :custom_resource
+
+action :create do
+  file '/tmp/hi'
+end
+
+action_class do
+  def whyrun_supported?
+    true
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -19,3 +19,6 @@ end
 describe file('/tmp/log_another_log') do
   it { should be_file }
 end
+describe file('/tmp/log_a_log_defined_after_choregraphie') do
+  it { should be_file }
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
-describe file('/tmp/execute_converging') do
-  it { should be_file }
-end
-describe file('/tmp/execute_not_converging') do
-  it { should_not be_file }
+
+%w(
+/tmp/execute_converging
+/tmp/test_simple_resource_converging
+/tmp/log_a_simple_log
+/tmp/log_another_log
+/tmp/log_a_log_defined_after_choregraphie
+/tmp/custom_resource_my_converging_custom_resource
+).each do |path|
+  describe file(path) do
+    it { should be_file }
+  end
 end
 
-describe file('/tmp/test_simple_resource_converging') do
-  it { should be_file }
-end
-describe file('/tmp/test_simple_resource_not_converging') do
-  it { should_not be_file }
-end
-
-describe file('/tmp/log_a_simple_log') do
-  it { should be_file }
-end
-describe file('/tmp/log_another_log') do
-  it { should be_file }
-end
-describe file('/tmp/log_a_log_defined_after_choregraphie') do
-  it { should be_file }
+%w(
+/tmp/execute_not_converging
+/tmp/test_simple_resource_not_converging
+/tmp/custom_resource_my_useless_custom_resource
+).each do |path|
+  describe file(path) do
+    it { should_not be_file }
+  end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -12,3 +12,10 @@ end
 describe file('/tmp/test_simple_resource_not_converging') do
   it { should_not be_file }
 end
+
+describe file('/tmp/log_a_simple_log') do
+  it { should be_file }
+end
+describe file('/tmp/log_another_log') do
+  it { should be_file }
+end


### PR DESCRIPTION
If custom_resource is defined with an explicity support for why-run,
choregraphie works correctly.

See chef/chef#4537
