### PR TITLE
Allow to select "weigthed" resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Example
       # protect against all reboot resources
       on /^reboot\[/
 
+      on :weighted_resources # compatiblity with resource-weight cookbook
+
       # built-in primitive
       consul_lock(path: 'choregraphie/locks/myes', concurrency: 2)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,5 @@ source_url       'https://github.com/criteo-cookbooks/choregraphie'
 version          '0.6.0'
 supports         'centos'
 supports         'windows'
+
+depends          'resource-weight'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -47,6 +47,10 @@ custom_resource 'my useless custom resource' do
   only_if { false }
 end
 
+execute 'uname' do
+  weight 2
+end
+
 choregraphie 'execute' do
   on 'execute[converging]'
   on 'execute[not_converging]'
@@ -56,6 +60,8 @@ choregraphie 'execute' do
   on 'custom_resource[my useless custom resource]'
 
   on /^log\[/
+
+  on :weighted_resources
 
   before do |resource|
     Chef::Log.warn("I am called before! for resource " + resource.to_s)

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -9,6 +9,7 @@ log_a_simple_log
 log_another_log
 log_a_log_defined_after_choregraphie
 custom_resource_my_converging_custom_resource
+execute_uname
 ).each do |path|
   describe file(::File.join(dir, path)) do
     it { should be_file }


### PR DESCRIPTION
Integration with resource-weight cookbook will allow to avoid the
maintainance of protected resources inside each choregraphie.

Cookbook owners will declare the weight of the resource they expose and
they could be automatically protected by choregraphie