### PR TITLE
Add "finish" stage that runs atthe ned after cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ Two very basic primitives:
 
 * Before: `before { ... }` will execute code before protected resources are converged. The block will receive the converged resource as argument.
 * Cleanup: `cleanup { ... }` will execute code at the end of a successful chef-client run. The cleanup block will be executed at *each* chef-client run. This code should thus be efficient and safe to run at the end of all chef-client runs (for instance cleaning a file only if it exists).
+* Finish: `finish { ... }` wil execute code after cleanup stage. There can be only one finish block.
 
 
 Slightly more advanced primitives:
 * CheckFile: `check_file '/tmp/do_it'` will wait until the given file exists on the filesystem. This file is cleaned after.
 * WaitUntil: `wait_until "ping -c 1 google.com"` will wait until the command exit with a 0 status. This primitives supports string, mixlib/shellout instance and blocks. One can specify to run the wait_until in "before" or "cleanup" stages using the options (see code for details)
-* ConsulLock: `consul_lock {path: '/lock/my_app', id: 'my_node', concurrency: 5}` will grab a lock from consul and release it afterwards. This primitive is based on optimistic concurrency rather than consul sessions.
+* ConsulLock: `consul_lock {path: '/lock/my_app', id: 'my_node', concurrency: 5}` will grab a lock from consul and release it afterwards. This primitive is based on optimistic concurrency rather than consul sessions. It uses `finish` block to release the lock ensuring that the lock release happens after all cleanup blocks.
 * ConsulMaintenance: `consul_maintenance reason: 'My reason'` will enable
   maintenance mode on the consul agent before the choregraphie starts.
 

--- a/libraries/primitive_consul_lock.rb
+++ b/libraries/primitive_consul_lock.rb
@@ -86,7 +86,7 @@ module Choregraphie
         wait_until(:enter) { semaphore.enter(@options[:id]) }
       end
 
-      choregraphie.cleanup do
+      choregraphie.finish do
         # hack: We can ignore failure there since it is only to release
         # the lock. If there is a temporary failure, we can wait for the
         # next run to release the lock without compromising safety.

--- a/spec/unit/primitive_consul_lock_spec.rb
+++ b/spec/unit/primitive_consul_lock_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../../libraries/primitive_consul_lock'
 require 'webmock/rspec'
 require 'base64'
+require 'diplomat'
 
 describe Choregraphie::ConsulLock do
   let(:choregraphie) do
@@ -36,7 +37,7 @@ describe Choregraphie::ConsulLock do
 
         expect(Semaphore).to receive(:get_or_create).and_return(*([failing_lock] * fails + [lock]))
 
-        choregraphie.cleanup.each { |block| block.call }
+        choregraphie.finish.each { |block| block.call }
       end
     end
   end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 describe 'test::default' do
   context 'When all attributes are default, on centos 6.7' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
+      runner = ChefSpec::ServerRunner.new(
         platform: 'centos',
         version:  '6.7'
       )
@@ -23,7 +23,7 @@ describe 'test::default' do
   end
   context 'When all attributes are default, on centos 7.2.1511' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
+      runner = ChefSpec::ServerRunner.new(
         platform: 'centos',
         version:  '7.2.1511'
       )
@@ -37,7 +37,7 @@ describe 'test::default' do
   end
   context 'When all attributes are default, on windows 6.3.9600' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
+      runner = ChefSpec::ServerRunner.new(
         platform: 'windows',
         version:  '2008R2'
       )

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -66,14 +66,18 @@ choregraphie 'execute' do
   before do |resource|
     Chef::Log.warn("I am called before! for resource " + resource.to_s)
     filename = resource.to_s.gsub(/\W+/, '_').gsub(/_$/,'')
-    require 'fileutils'
-    require 'tmpdir'
-    dir = Dir.tmpdir()
-    FileUtils.touch(::File.join(dir, filename))
+    File.open(::File.join(dir, filename), 'a') { |file| file.write("before\n") }
   end
-  cleanup do
-    Chef::Log.warn('I am called at the end')
+  cleanup do |resource|
+    Chef::Log.warn('I am called at cleanup for cleanup block')
+    text = resource.to_s.gsub(/\W+/, '_').gsub(/_$/,'')
+    File.open(::File.join(dir, 'cleanup'), 'a') { |file| file.write("#{text}\n") }
   end
+  finish do
+    Chef::Log.warn('I am called at finish block')
+    File.open(::File.join(dir, 'cleanup'), 'a') { |file| file.write("finish") }
+  end
+
 end
 
 log "a_log_defined_after_choregraphie"

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -14,6 +14,9 @@ execute_uname
   describe file(::File.join(dir, path)) do
     it { should be_file }
   end
+  describe file(::File.join(dir, 'cleanup')) do
+    its(:content) { should match /\nfinish$/}
+  end
 end
 
 %w(


### PR DESCRIPTION
To allow the lock release to be the last step without breaking API
I add a finish stage that runs at the end after all cleanup runs.
The choregraphie block can only have one "finish".
consul_lock primitive uses it to release the lock.