### PR TITLE
Add option to hook on converge start

### DIFF
--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -172,9 +172,16 @@ module Choregraphie
             raise "Resource #{resource} does not respond to :weight method. There is most likely a bug in resource-weight cookbook"
           end
         end
-
+      when :converge_start
+        before_events = method(:before)
+        Chef.event_handler do
+          on :converge_start do
+            Chef::Log.info "Chef client starting to converge, running before callbacks."
+            before_events.call.each { |b| b.call }
+          end
+        end
       else
-        #TODO
+        # TODO
         raise "Symbol type is not yet supported"
       end
     end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -62,10 +62,16 @@ choregraphie 'execute' do
   on /^log\[/
 
   on :weighted_resources
+  on :converge_start
 
   before do |resource|
-    Chef::Log.warn("I am called before! for resource " + resource.to_s)
-    filename = resource.to_s.gsub(/\W+/, '_').gsub(/_$/,'')
+    filename = if resource.nil?
+                 Chef::Log.warn("I am called before! for converge start")
+                 'converge_start'
+               else
+                 Chef::Log.warn("I am called before! for resource " + resource.to_s)
+                 resource.to_s.gsub(/\W+/, '_').gsub(/_$/,'')
+               end
     File.open(::File.join(dir, filename), 'a') { |file| file.write("before\n") }
   end
   cleanup do |resource|
@@ -77,7 +83,6 @@ choregraphie 'execute' do
     Chef::Log.warn('I am called at finish block')
     File.open(::File.join(dir, 'cleanup'), 'a') { |file| file.write("finish") }
   end
-
 end
 
 log "a_log_defined_after_choregraphie"


### PR DESCRIPTION
Allows running actions at the beginning of the
convergence phase before all other resources.