### PR TITLE
Allow to take consul lock in another datacenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Three very basic primitives:
 Slightly more advanced primitives:
 * CheckFile: `check_file '/tmp/do_it'` will wait until the given file exists on the filesystem. This file is cleaned after.
 * WaitUntil: `wait_until "ping -c 1 google.com"` will wait until the command exit with a 0 status. This primitives supports string, mixlib/shellout instance and blocks. One can specify to run the wait_until in "before" or "cleanup" stages using the options (see code for details).
-* ConsulLock: `consul_lock {path: '/lock/my_app', id: 'my_node', concurrency: 5}` will grab a lock from consul and release it afterwards. This primitive is based on optimistic concurrency rather than consul sessions. It uses `finish` block to release the lock ensuring that the lock release happens after all cleanup blocks.
+* ConsulLock: `consul_lock {path: '/lock/my_app', id: 'my_node', concurrency: 5}` will grab a lock from consul and release it afterwards. This primitive is based on optimistic concurrency rather than consul sessions. It uses `finish` block to release the lock ensuring that the lock release happens after all cleanup blocks. It is also possible to specify the `:datacenter` option to take the lock in another datacenter.
 * ConsulRackLock: `consul_rack_lock {path: '/lock/my_app', id: 'my_node', rack: 'my_rack_id', concurrency: 2}` will grab a lock from consul and release it afterwards. This has the same properties as ConsulLock but will allow in node to enter if another node with the same rack is already under the lock. Concurrency level is on the number of concurrent racks (not on concurrent nodes per rack).
 * ConsulMaintenance: `consul_maintenance reason: 'My reason'` will enable.
   maintenance mode on the consul agent before the choregraphie starts.

--- a/spec/unit/primitive_consul_lock_spec.rb
+++ b/spec/unit/primitive_consul_lock_spec.rb
@@ -62,7 +62,7 @@ describe Choregraphie::ConsulLock do
       lock = double('lock')
       expect(lock).to receive(:enter).with(name: "my_node").and_return(true)
 
-      expect(Semaphore).to receive(:get_or_create).with('/chef_lock/test', 3).and_return(lock)
+      expect(Semaphore).to receive(:get_or_create).with('/chef_lock/test', 3, dc: nil).and_return(lock)
 
       choregraphie_service.before.each { |block| block.call }
     end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -17,7 +17,7 @@ end
 
 # Using chef provided resource
 execute 'converging' do
-  command 'uname'
+  command 'whoami'
 end
 execute 'not_converging' do
   command 'reboot'
@@ -47,7 +47,7 @@ custom_resource 'my useless custom resource' do
   only_if { false }
 end
 
-execute 'uname' do
+execute 'whoami' do
   weight 2
 end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -9,7 +9,7 @@ log_a_simple_log
 log_another_log
 log_a_log_defined_after_choregraphie
 custom_resource_my_converging_custom_resource
-execute_uname
+execute_whoami
 ).each do |path|
   describe file(::File.join(dir, path)) do
     it { should be_file }


### PR DESCRIPTION
This patch enhances consul_lock primitive to allow to specify datacenter
option.

> consul_lock { path: '/lock/my_path', concurrency: 5, id: node.name, dc:
'par' }

This option decreases availability but allow to have worldwide lock.

Next step would be to have an available global lock when needed.

Change-Id: Icd77ee0b4008d3ecba053b6824f2d3755a6b6c14