### PR TITLE
Add the EnsureChoregraphie primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Slightly more advanced primitives:
 * ConsulMaintenance: `consul_maintenance reason: 'My reason'` will enable.
   maintenance mode on the consul agent before the choregraphie starts.
 * ConsulHealthCheck: `consul_health_check(checkids: %w(service:consul-http-agent service:myhealthcheck))` will block until consul health check is passing. By default it will wait for 150s before failing the chef run. ids for checkids are the composition of the check type  and the id of the check (For ex. for service check myhealthcheck, id is service:myhealthcheck`).
+* EnsureChoregraphie: `ensure_choregraphie` will make sure that another
+  choregraphie is already protecting the resources, or wait for a file (an
+  optional file path can be provided). This primitive is useful for cookbook
+  providers to make sure users will protect some critical
+  resources.
 
 Note: all primitives interacting with consul require the diplomat gem. You can easily install it with consul cookbook.
 

--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -7,7 +7,20 @@ require 'chef/provider'
 module Choregraphie
   class Choregraphie
 
+    @@choregraphies = {}
+
+    def self.all
+      @@choregraphies.values
+    end
+
+    def self.add(choregraphie)
+      raise "Choregraphie #{choregraphie.name} is already defined" if @@choregraphies[choregraphie.name]
+
+      @@choregraphies[choregraphie.name] = choregraphie
+    end
+
     attr_reader :name
+    attr_reader :resources
 
     def clean_name
       name.gsub(/[^a-z]+/, '_')
@@ -15,6 +28,8 @@ module Choregraphie
 
     def initialize(name, &block)
       @name = name
+      # Contain the list of resources protected by this choregraphie
+      @resources = []
       @before = []
       @cleanup = []
       @finish = []
@@ -121,6 +136,7 @@ module Choregraphie
     end
 
     def setup_hook(resource_name, opts)
+      resources << resource_name
 
       # catch before in the closure
       before_events = method(:before)

--- a/libraries/dsl.rb
+++ b/libraries/dsl.rb
@@ -3,7 +3,7 @@ module Choregraphie
 
     # DSL helper
     def choregraphie(name)
-      Choregraphie.new(name, &Proc.new)
+      Choregraphie.add(Choregraphie.new(name, &Proc.new))
     end
   end
 end

--- a/libraries/primitive.rb
+++ b/libraries/primitive.rb
@@ -3,7 +3,7 @@ require_relative 'choregraphie'
 module Choregraphie
 
   class Primitive
-    @@primitives    = []
+    @@primitives    ||= []
 
     def register(choregraphie)
       raise NotImplementedError, "You must implement :register method"

--- a/libraries/primitive_ensure_choregraphie.rb
+++ b/libraries/primitive_ensure_choregraphie.rb
@@ -1,0 +1,31 @@
+require_relative 'primitive'
+
+module Choregraphie
+  class EnsureChoregraphie < Primitive
+    def initialize(file_path = ::File.join(::Chef::Config['file_cache_path'], 'unlock_choregraphie'), options = {})
+      @file_path = file_path
+      @period    = options[:period] || 5
+    end
+
+
+    def register(choregraphie)
+      # We clear the resources list since we do not want other choregraphies
+      # with to think that they are protected.
+      choregraphie.resources.clear
+
+      choregraphie.before do |resource_name|
+        raise 'ensure_choregraphie primitive cannot be used on other events than resource convergence!' unless resource_name
+
+        if ::Choregraphie::Choregraphie.all.none? { |c| c.resources.include?(resource_name) }
+          Chef::Log.warn "Resource #{resource_name} is about to converge but no choregraphie has been set up to protect this, please touch file #{@file_path} if you want to converge anyway."
+          sleep(@period) until ::File.exists?(@file_path)
+        end
+      end
+
+      choregraphie.cleanup do
+        ::FileUtils.rm(@file_path) if File.exists?(@file_path)
+      end
+
+    end
+  end
+end

--- a/spec/unit/primitive_ensure_choregraphie.rb
+++ b/spec/unit/primitive_ensure_choregraphie.rb
@@ -1,0 +1,37 @@
+require_relative '../../libraries/primitive_ensure_choregraphie'
+
+describe Choregraphie::EnsureChoregraphie do
+  let(:choregraphie) do
+    Choregraphie::Choregraphie.new('test') do
+      on 'test[name]'
+      ensure_choregraphie 'random', period: 0.01
+    end
+  end
+  before(:each) do
+    expect_any_instance_of(Choregraphie::Choregraphie).to receive(:ruby_block)
+  end
+
+  it 'must check file if resource is not protected' do
+    expect(Choregraphie::Choregraphie).to receive(:all).and_return(
+      [
+        double(name: 'test', resources: ['test[name]']),
+        double(name: 'test2', resources: [])
+      ])
+    expect(File).to receive(:exists?).with('random').and_return(true)
+    choregraphie.before.each { |block| block.call 'test[name]' }
+  end
+  it 'must not check file if resource is protected' do
+    expect(Choregraphie::Choregraphie).to receive(:all).and_return(
+      [
+        double(name: 'test', resources: ['test[name]']),
+        double(name: 'test2', resources: ['test[name]'])
+      ])
+    expect(File).to_not receive(:exists?).with('random')
+    choregraphie.before.each { |block| block.call 'test[name]' }
+  end
+  it 'must clean the file in cleanup' do
+    expect(File).to receive(:exists?).and_return(true)
+    expect(FileUtils).to receive(:rm).with('random')
+    choregraphie.cleanup.each { |block| block.call }
+  end
+end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -51,6 +51,11 @@ execute 'whoami' do
   weight 2
 end
 
+choregraphie 'ensure_weight' do
+  on :weighted_resources
+  ensure_choregraphie
+end
+
 choregraphie 'execute' do
   on 'execute[converging]'
   on 'execute[not_converging]'


### PR DESCRIPTION
`ensure_choregraphie` will make sure that another choregraphie is already protecting the resources, or wait for a file (inherits from `check_file`: an optional file path can be provided). This primitive is useful for cookbook providers to make sure users will protect some critical resources.
