### PR TITLE
Improve consul maintenance cleanup

### DIFF
--- a/spec/unit/primitive_consul_maintenance_spec.rb
+++ b/spec/unit/primitive_consul_maintenance_spec.rb
@@ -10,13 +10,30 @@ describe Choregraphie::ConsulMaintenance do
 
   context 'When using consul_maintenance' do
     it 'Must enable maintenance mode before' do
+      stub_request(:get, "localhost:8500/v1/agent/checks").to_return(status: 200, body: "{}")
       expect(Diplomat::Maintenance).to receive(:enable).with(true, 'Testing').and_return(true)
       choregraphie.before.each { |block| block.call }
     end
 
-    it 'Must disable maintenance mode before' do
+    it 'Must disable maintenance mode in cleanup' do
+      stub_request(:get, "localhost:8500/v1/agent/checks")
+        .to_return(status: 200, body: '{"_node_maintenance": {"CheckID": "_node_maintenance", "Status": "critical", "Notes": "Testing"}}')
       expect(Diplomat::Maintenance).to receive(:enable).with(false, 'Testing').and_return(true)
       choregraphie.cleanup.each { |block| block.call }
     end
+
+    it 'Must not disable maintenance mode in cleanup if enabled for other reasons' do
+      stub_request(:get, "localhost:8500/v1/agent/checks")
+        .to_return(status: 200, body: '{"_node_maintenance": {"CheckID": "_node_maintenance", "Status": "critical", "Notes": "for reasons..."}}')
+      expect(Diplomat::Maintenance).to_not receive(:enable)
+      choregraphie.cleanup.each { |block| block.call }
+    end
+
+    #it 'Must not disable maintenance mode in cleanup if not enabled' do
+    #  stub_request(:get, "localhost:8500/v1/agent/checks").to_return(status: 200, body: "{}")
+    #  expect(Diplomat::Maintenance).to_not receive(:enable)
+    #  choregraphie.cleanup.each { |block| block.call }
+    #end
+
   end
 end


### PR DESCRIPTION
- previously, any chef run would disable consul maintenance.
- now the maintenance is disabled only if the reason match (so if the
maintenance was set by us with high probability).
- some logs was added to ease troubleshooting

Signed-off-by: Cyril Martin <c.martin@criteo.com>