### PR TITLE
Avoid infinite loop when hooking on resources using regexp

### DIFF
--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -208,7 +208,10 @@ module Choregraphie
       myself = self
       Chef.event_handler do
         on :converge_start do |run_context|
-          run_context.resource_collection.each do |resource|
+          # yielded block can (and will) modify the resource collection
+          # (for instance by adding resources)
+          collection_copy = run_context.resource_collection.map(&:itself)
+          collection_copy.each do |resource|
             yield resource, myself
           end
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Coordinates the application of changes induced by chef'
 long_description 'Installs/Configures choregraphie'
 issues_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :issues_url
 source_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :source_url
-version          '0.14.1'
+version          '0.14.2'
 supports         'centos'
 supports         'windows'
 


### PR DESCRIPTION
When using the following syntax:
```
choregraphie 'toto' do
  on /something/
end
```

we used to trigger a infinite loop because choregraphie creates
resources named "ruby_block[before callback to protect resource ...toto]"

Most of our known users have the following syntax: `on /^file[...]/`
which miraculously protected them against this bug.

This patch fixes a rookie mistake (mine): iterating over a collection
that is modified by each iteration.

Change-Id: Id5afb7ad4e8d29861b01d3e1bbd23007edb7c2fc