### PR TITLE
Add experimental `after` primitive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.3.0
+- 2.4.0
 deploy:
   skip_cleanup: true
   edge:

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,4 @@ gem 'diplomat',      '>= 2.0.2'
 
 gem 'winrm-elevated'
 gem 'rubocop', '=0.45.0'
+gem 'openssl', '>= 2.0.5'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'berkshelf'
 gem 'kitchen-vagrant'
-gem 'chefspec'
+gem 'chefspec', '< 7.3.0'
 gem 'rake'
 gem 'foodcritic'
 gem 'chef-zero-scheduled-task'

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Available Primitives
 
 See the code for up-to-date information.
 
-Three very basic primitives:
+Four very basic primitives:
 
 * Before: `before { ... }` will execute code before protected resources are converged. The block will receive the converged resource as argument.
 * Cleanup: `cleanup { ... }` will execute code at the end of a successful chef-client run. The cleanup block will be executed at *each* chef-client run. This code should thus be efficient and safe to run at the end of all chef-client runs (for instance cleaning a file only if it exists).
+* After: `after { ... }` will execute code at the end of choregraphie. The after block will be executed at the end of choregraphie but *might* be executed after some chef-client run. It does best-effort to avoid running when not necessary, code run in `after` must cope with useless run though.
 * Finish: `finish { ... }` will execute code after cleanup stage. There can be only one finish block.
 
 

--- a/libraries/primitive_after.rb
+++ b/libraries/primitive_after.rb
@@ -1,0 +1,57 @@
+require_relative 'primitive'
+
+module Choregraphie
+  class After < Primitive
+    def initialize(&block)
+      @block = block
+    end
+
+    def register(choregraphie)
+      @choregraphie_name = choregraphie.name
+
+      choregraphie.before do
+        set_in_progress
+      end
+
+      choregraphie.cleanup do
+        if in_progress?
+          @block.call
+          set_not_in_progress
+        elsif !installed? # we are after a reinstallation, we can't know if we were in a choregraphie or not, run the block just in case
+          @block.call
+        end
+        set_installed
+      end
+    end
+
+    def in_progress?
+      File.exist?(inprogress_marker)
+    end
+
+    def set_in_progress
+      FileUtils.touch(inprogress_marker)
+    end
+
+    def set_not_in_progress
+      FileUtils.rm(inprogress_marker)
+    end
+
+    def installed?
+      File.exist?(install_marker)
+    end
+
+    def set_installed
+      FileUtils.touch(install_marker)
+    end
+
+    private
+
+    def inprogress_marker
+      File.join(Chef::Config[:file_cache_path], "choregraphie-#{@choregraphie_name.gsub(/[^a-zA-Z0-9]/, '_')}-inprogress")
+    end
+
+    def install_marker
+      File.join(Chef::Config[:file_cache_path], "choregraphie-#{@choregraphie_name.gsub(/[^a-zA-Z0-9]/, '_')}-installed")
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Coordinates the application of changes induced by chef'
 long_description 'Installs/Configures choregraphie'
 issues_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :issues_url
 source_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :source_url
-version          '0.14.3'
+version          '0.15.0'
 supports         'centos'
 supports         'windows'
 

--- a/rakelib/35-rspec.rake
+++ b/rakelib/35-rspec.rake
@@ -1,5 +1,7 @@
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:rspec)
+RSpec::Core::RakeTask.new(:rspec) do |t|
+  t.rspec_opts = '-fd'
+end
 
 task default: [:rspec]

--- a/spec/unit/lock_spec.rb
+++ b/spec/unit/lock_spec.rb
@@ -33,7 +33,7 @@ describe Choregraphie::Semaphore do
         stub_request(:get, "http://localhost:8500/v1/kv/check-lock/my_lock").
           to_return(existing_response)
 
-        expect(Semaphore.get_or_create('/check-lock/my_lock', 2)).to be_a(Semaphore)
+        expect(Semaphore.get_or_create('check-lock/my_lock', 2)).to be_a(Semaphore)
       end
     end
 
@@ -46,7 +46,7 @@ describe Choregraphie::Semaphore do
           with(:body => "{\"version\":1,\"concurrency\":2,\"holders\":{}}").
           to_return( status: 200, body: "true")
 
-        expect(Semaphore.get_or_create('/check-lock/my_lock', 2)).to be_a(Semaphore)
+        expect(Semaphore.get_or_create('check-lock/my_lock', 2)).to be_a(Semaphore)
       end
     end
   end
@@ -54,14 +54,14 @@ describe Choregraphie::Semaphore do
   let(:lock) do
     value = {version: 1, concurrency: 5, holders: {another_node: 12345 }}.to_json
     Semaphore.new(
-      '/check-lock/my_lock',
+      'check-lock/my_lock',
       { 'Value' => value, 'ModifyIndex' => 42 }
     )
   end
   let(:full_lock) do
     value = {version: 1, concurrency: 1, holders: {another_node: 12345 }}.to_json
     Semaphore.new(
-      '/check-lock/my_lock',
+      'check-lock/my_lock',
       { 'Value' => value, 'ModifyIndex' => 42 }
     )
   end

--- a/spec/unit/primitive_after_spec.rb
+++ b/spec/unit/primitive_after_spec.rb
@@ -1,0 +1,104 @@
+require_relative '../../libraries/primitive_after'
+
+describe Choregraphie::After do
+  let(:block) { proc {} }
+  let(:choregraphie) do
+    Choregraphie::Choregraphie.new('test') do
+      after(&block)
+    end
+  end
+
+  describe 'standard behavior' do
+    before do
+      # all file manipulation are no-op
+      allow(FileUtils).to receive(:touch)
+      allow(FileUtils).to receive(:rm)
+    end
+
+    context 'when node has been installed long time ago' do
+      before do
+        allow(File).to receive(:exist?).with(/installed/).and_return(true)
+      end
+
+      context 'when a choregraphie starts' do
+        it 'must mark its in progress state' do
+          expect(FileUtils).to receive(:touch).with(/inprogress/)
+          choregraphie.before.each(&:call)
+        end
+      end
+
+      context 'when a choregraphie is in progress' do
+        it 'must call its block' do
+          allow(File).to receive(:exist?).with(/inprogress/).and_return(true)
+          expect(block).to receive(:call)
+          choregraphie.cleanup.each(&:call)
+        end
+      end
+
+      context 'when no choregraphie is in progress' do
+        it 'must not call its block' do
+          allow(File).to receive(:exist?).with(/inprogress/).and_return(false)
+          expect(block).not_to receive(:call)
+          choregraphie.cleanup.each(&:call)
+        end
+      end
+    end
+
+    context 'when node has just been installed' do
+      before do
+        allow(File).to receive(:exist?).with(/installed/).and_return(false)
+      end
+      context 'when a choregraphie is in progress' do
+        before { allow(File).to receive(:exist?).with(/inprogress/).and_return(true) }
+        it 'must call its block' do
+          expect(block).to receive(:call)
+          choregraphie.cleanup.each(&:call)
+        end
+        it 'must mark server as "installed"' do
+          expect(FileUtils).to receive(:touch).with(/installed/)
+          choregraphie.cleanup.each(&:call)
+        end
+      end
+
+      context 'when no choregraphie is marked in progress' do
+        before { allow(File).to receive(:exist?).with(/inprogress/).and_return(false) }
+        it 'must call its block' do
+          expect(block).to receive(:call)
+          choregraphie.cleanup.each(&:call)
+        end
+
+        it 'must mark server as "installed"' do
+          expect(FileUtils).to receive(:touch).with(/installed/)
+          choregraphie.cleanup.each(&:call)
+        end
+      end
+    end
+  end
+
+  describe 'invariants' do
+    subject { Choregraphie::After.new }
+    before { subject.register(choregraphie) }
+
+    describe '.set_in_progress' do
+      let(:cache_dir) { Dir.mktmpdir }
+
+      before { Chef::Config[:file_cache_path] = cache_dir }
+      after { FileUtils.rm_rf(cache_dir) }
+
+      it 'makes in_progress? change behavior' do
+        expect { subject.set_in_progress }.to change { subject.in_progress? }.to(true)
+      end
+    end
+
+    describe '.set_installed' do
+      let(:cache_dir) { Dir.mktmpdir }
+
+      before { Chef::Config[:file_cache_path] = cache_dir }
+      after { FileUtils.rm_rf(cache_dir) }
+
+      it 'makes installed? change behavior' do
+        expect { subject.set_installed }.to change { subject.installed? }.to(true)
+      end
+    end
+  end
+end

--- a/spec/unit/rack_lock_spec.rb
+++ b/spec/unit/rack_lock_spec.rb
@@ -35,7 +35,7 @@ describe Choregraphie::SemaphoreByRack do
         stub_request(:get, 'http://localhost:8500/v1/kv/check-lock/my_lock')
           .to_return(existing_response)
 
-        expect(SemaphoreByRack.get_or_create('/check-lock/my_lock', 2)).to be_a(SemaphoreByRack)
+        expect(SemaphoreByRack.get_or_create('check-lock/my_lock', 2)).to be_a(SemaphoreByRack)
       end
     end
 
@@ -48,7 +48,7 @@ describe Choregraphie::SemaphoreByRack do
           .with(body: '{"version":1,"concurrency":2,"holders":{}}')
           .to_return(status: 200, body: 'true')
 
-        expect(SemaphoreByRack.get_or_create('/check-lock/my_lock', 2)).to be_a(SemaphoreByRack)
+        expect(SemaphoreByRack.get_or_create('check-lock/my_lock', 2)).to be_a(SemaphoreByRack)
       end
     end
   end
@@ -56,21 +56,21 @@ describe Choregraphie::SemaphoreByRack do
   let(:lock) do
     value = { version: 1, concurrency: 5, holders: { another_rack: { another_node: 12_345 } } }.to_json
     SemaphoreByRack.new(
-      '/check-lock/my_lock',
+      'check-lock/my_lock',
       'Value' => value, 'ModifyIndex' => 42,
     )
   end
   let(:full_lock) do
     value = { version: 1, concurrency: 1, holders: { another_rack: { another_node: 12_345 } } }.to_json
     SemaphoreByRack.new(
-      '/check-lock/my_lock',
+      'check-lock/my_lock',
       'Value' => value, 'ModifyIndex' => 42,
     )
   end
   let(:taken_lock) do
     value = { version: 1, concurrency: 5, holders: { my_rack: { myself: 12_345, another_node: 123_456 } } }.to_json
     SemaphoreByRack.new(
-      '/check-lock/my_lock',
+      'check-lock/my_lock',
       'Value' => value, 'ModifyIndex' => 42,
     )
   end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe 'test::default' do
-  context 'When all attributes are default, on centos 6.7' do
+  context 'When all attributes are default, on centos 7.5.1804' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos',
-        version:  '6.7'
+        version:  '7.5.1804'
       )
       stub_command("test -f /tmp/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
@@ -15,25 +15,11 @@ describe 'test::default' do
       expect { chef_run }.to_not raise_error
     end
   end
-  context 'When all attributes are default, on centos 7.2.1511' do
-    let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(
-        platform: 'centos',
-        version:  '7.2.1511'
-      )
-      stub_command("test -f /tmp/not_converging.tmp").and_return(0)
-      runner.converge(described_recipe)
-    end
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
-  end
-  context 'When all attributes are default, on windows 6.3.9600' do
+  context 'When all attributes are default, on windows 8.1' do
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'windows',
-        version:  '2008R2'
+        version:  '8.1'
       )
       stub_command("test -f /tmp/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'test::default' do
   context 'When all attributes are default, on centos 7.5.1804' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(
+      runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
         version:  '7.5.1804'
       )
@@ -17,7 +17,7 @@ describe 'test::default' do
   end
   context 'When all attributes are default, on windows 8.1' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(
+      runner = ChefSpec::SoloRunner.new(
         platform: 'windows',
         version:  '8.1'
       )


### PR DESCRIPTION
This primitive aims to improve the cleanup primitive by not running at
every chef-client convergence.

Change-Id: I6b97caaecc0c6ca5878e43623086e7b20d38cd89