### PR TITLE
Log datacenter used for consul_lock primitive

### DIFF
--- a/libraries/primitive_consul_lock.rb
+++ b/libraries/primitive_consul_lock.rb
@@ -67,7 +67,8 @@ module Choregraphie
     end
 
     def wait_until(action, opts = {})
-      Chef::Log.info "Will #{action} the lock #{path}"
+      dc = "(in #{@options[:datacenter]})" if @options[:datacenter]
+      Chef::Log.info "Will #{action} the lock #{path} #{dc}"
       success = 0.upto(opts[:max_failures] || Float::INFINITY).any? do |tries|
         begin
           yield || backoff


### PR DESCRIPTION
Default is to use the local datacenter but it can be overriden.
This patch logs the datacenter used (unless it is the local one).

This can be useful for user trying to read lock status

Change-Id: Ib49b0f72ffffea9ab1418da9c55841f12eb99f7b