### PR TITLE
Fix unhandled error when Consul check is not registered

### DIFF
--- a/libraries/primitive_consul_health.rb
+++ b/libraries/primitive_consul_health.rb
@@ -37,6 +37,10 @@ module Choregraphie
           next
         end
 
+        @options[:checkids].each do |check_id|
+          raise "Check #{check_id} is not registered" unless checks.key?(check_id)
+        end
+
         non_passing = @options[:checkids]
           .select { |id| checks[id]['CheckID'] }
           .reject { |id| checks[id]['Status'] == 'passing' }

--- a/spec/unit/primitive_consul_health_spec.rb
+++ b/spec/unit/primitive_consul_health_spec.rb
@@ -49,4 +49,17 @@ describe Choregraphie::ConsulHealthCheck do
       choregraphie.cleanup.each(&:call)
     end
   end
+
+  context %(when the service doesn't exist) do
+    it 'must fail with an explicit error' do
+      stub_request(:get, 'http://localhost:8500/v1/agent/checks')
+        .to_return([
+          {
+            body: {}.to_json,
+          },
+        ] * 3,)
+
+      expect { choregraphie.cleanup.each(&:call) }.to raise_error(/Check service:ping is not registered/)
+    end
+  end
 end


### PR DESCRIPTION
And raise an explicit error when this is the case.

Otherwise we get this kind of unfriendly stack trace:
```
#<NoMethodError: undefined method `[]' for nil:NilClass> with backtrace:
         # ./libraries/primitive_consul_health.rb:45:in `block (2 levels) in are_checks_passing?'
         # ./libraries/primitive_consul_health.rb:45:in `select'
         # ./libraries/primitive_consul_health.rb:45:in `block in are_checks_passing?'
         # ./libraries/primitive_consul_health.rb:28:in `times'
         # ./libraries/primitive_consul_health.rb:28:in `are_checks_passing?'
         # ./libraries/primitive_consul_health.rb:58:in `block in register'
```