### PR TITLE
Fixed unit assuming /tmp is  (wrong on OSX for instance)

### DIFF
--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,7 +7,7 @@ describe 'test::default' do
         platform: 'centos',
         version:  '7.5.1804'
       )
-      stub_command("test -f /tmp/not_converging.tmp").and_return(0)
+      stub_command("test -f #{Dir.tmpdir()}/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end
 
@@ -21,7 +21,7 @@ describe 'test::default' do
         platform: 'windows',
         version:  '8.1'
       )
-      stub_command("test -f /tmp/not_converging.tmp").and_return(0)
+      stub_command("test -f #{Dir.tmpdir()}/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end
 


### PR DESCRIPTION
This fixes Unit tests on Mac OS X