### PR TITLE
Ensure after works correctly when multiple instances are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Four very basic primitives:
 
 * Before: `before { ... }` will execute code before protected resources are converged. The block will receive the converged resource as argument.
 * Cleanup: `cleanup { ... }` will execute code at the end of a successful chef-client run. The cleanup block will be executed at *each* chef-client run. This code should thus be efficient and safe to run at the end of all chef-client runs (for instance cleaning a file only if it exists).
-* After: `after { ... }` will execute code at the end of choregraphie. The after block will be executed at the end of choregraphie but *might* be executed after some chef-client run. It does best-effort to avoid running when not necessary, code run in `after` must cope with useless run though.
+* After: `after('name') { ... }` will execute code at the end of choregraphie. The after block will be executed at the end of choregraphie but *might* be executed after some chef-client run. It does best-effort to avoid running when not necessary, code run in `after` must cope with useless run though. It is important to give a unique name to this primitive (within the same choregraphie)
 * Finish: `finish { ... }` will execute code after cleanup stage. There can be only one finish block.
 
 

--- a/libraries/primitive_after.rb
+++ b/libraries/primitive_after.rb
@@ -2,8 +2,9 @@ require_relative 'primitive'
 
 module Choregraphie
   class After < Primitive
-    def initialize(&block)
+    def initialize(name, &block)
       @block = block
+      @name = name
     end
 
     def register(choregraphie)
@@ -47,11 +48,15 @@ module Choregraphie
     private
 
     def inprogress_marker
-      File.join(Chef::Config[:file_cache_path], "choregraphie-#{@choregraphie_name.gsub(/[^a-zA-Z0-9]/, '_')}-inprogress")
+      File.join(Chef::Config[:file_cache_path], "#{marker_prefix}-inprogress")
     end
 
     def install_marker
-      File.join(Chef::Config[:file_cache_path], "choregraphie-#{@choregraphie_name.gsub(/[^a-zA-Z0-9]/, '_')}-installed")
+      File.join(Chef::Config[:file_cache_path], "#{marker_prefix}-installed")
+    end
+
+    def marker_prefix
+      "choregraphie-#{@choregraphie_name.gsub(/[^a-zA-Z0-9]/, '_')}-#{@name.gsub(/[^a-zA-Z0-9]/, '_')}"
     end
   end
 end

--- a/spec/unit/primitive_after_spec.rb
+++ b/spec/unit/primitive_after_spec.rb
@@ -4,7 +4,7 @@ describe Choregraphie::After do
   let(:block) { proc {} }
   let(:choregraphie) do
     Choregraphie::Choregraphie.new('test') do
-      after(&block)
+      after('demo', &block)
     end
   end
 
@@ -76,7 +76,7 @@ describe Choregraphie::After do
   end
 
   describe 'invariants' do
-    subject { Choregraphie::After.new }
+    subject { Choregraphie::After.new('demo') }
     before { subject.register(choregraphie) }
 
     describe '.set_in_progress' do


### PR DESCRIPTION
Since we use file based markers, we need to use a unique identifier per
instance of "after" primitive to avoid running them (or not running
them) at the wrong time

Change-Id: If488ab493e3aec0148887ff85d441cdd00a0311e