### PR TITLE
Prevent error when lock path begins with '/'

### DIFF
--- a/libraries/primitive_consul_lock.rb
+++ b/libraries/primitive_consul_lock.rb
@@ -107,7 +107,7 @@ module Choregraphie
     private
 
     def path
-      @options[:path]
+      @options[:path].sub(/^\//,'')
     end
 
   end

--- a/spec/unit/primitive_consul_lock_spec.rb
+++ b/spec/unit/primitive_consul_lock_spec.rb
@@ -62,7 +62,7 @@ describe Choregraphie::ConsulLock do
       lock = double('lock')
       expect(lock).to receive(:enter).with(name: "my_node").and_return(true)
 
-      expect(Semaphore).to receive(:get_or_create).with('/chef_lock/test', 3, dc: nil).and_return(lock)
+      expect(Semaphore).to receive(:get_or_create).with('chef_lock/test', 3, dc: nil).and_return(lock)
 
       choregraphie_service.before.each { |block| block.call }
     end


### PR DESCRIPTION
Depending on the echosystem, in some cases HTTP 301 location
is not followed by faraday (Diplomat's web client) causing
an infinite loop while trying to fetch the lock.
By removing the first character if it's a '/' it will avoid this issue.