### PR TITLE
Add a way to clear registered choregraphie and use it in tests

### DIFF
--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -19,6 +19,10 @@ module Choregraphie
       @@choregraphies[choregraphie.name] = choregraphie
     end
 
+    def self.clear
+      @@choregraphies.clear
+    end
+
     attr_reader :name
     attr_reader :resources
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,7 +6,7 @@ describe 'test::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
         version:  '7.5.1804'
-      )
+      ) { ::Choregraphie::Choregraphie.clear }
       stub_command("test -f #{Dir.tmpdir()}/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end
@@ -20,7 +20,7 @@ describe 'test::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'windows',
         version:  '8.1'
-      )
+      ) { ::Choregraphie::Choregraphie.clear }
       stub_command("test -f #{Dir.tmpdir()}/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)
     end


### PR DESCRIPTION
With recent Chef and Chefspec versions, libraries are only loaded once.
Thus choregraphies registered during one test are kept for subsequents tests.