### PR TITLE
Ease debuggability of after primitive

### DIFF
--- a/libraries/primitive_after.rb
+++ b/libraries/primitive_after.rb
@@ -29,7 +29,7 @@ module Choregraphie
     end
 
     def set_in_progress
-      FileUtils.touch(inprogress_marker)
+      FileUtils.touch(inprogress_marker) unless in_progress?
     end
 
     def set_not_in_progress
@@ -41,7 +41,7 @@ module Choregraphie
     end
 
     def set_installed
-      FileUtils.touch(install_marker)
+      FileUtils.touch(install_marker) unless installed?
     end
 
     private

--- a/spec/unit/primitive_after_spec.rb
+++ b/spec/unit/primitive_after_spec.rb
@@ -22,6 +22,7 @@ describe Choregraphie::After do
 
       context 'when a choregraphie starts' do
         it 'must mark its in progress state' do
+          allow(File).to receive(:exist?).with(/inprogress/).and_return(false)
           expect(FileUtils).to receive(:touch).with(/inprogress/)
           choregraphie.before.each(&:call)
         end


### PR DESCRIPTION
It will more convenient to have marker files touched only when
necessary.

Change-Id: Ife2f1ea21358679a2ad444f06acd250fe047b9c2
