### PR TITLE
Fixup for consul primitive

### DIFF
--- a/libraries/primitive_consul_health.rb
+++ b/libraries/primitive_consul_health.rb
@@ -33,7 +33,7 @@ module Choregraphie
         end
 
         relevant_checks = checks.select do |id, check|
-          @options[:checkids]&.include?(id) || @options[:services].include?(check['ServiceName'])
+          @options[:checkids]&.include?(id) || @options[:services]&.include?(check['ServiceName'])
         end.values
 
         @options[:checkids]&.each do |check_id|

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Coordinates the application of changes induced by chef'
 long_description 'Installs/Configures choregraphie'
 issues_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :issues_url
 source_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :source_url
-version          '0.16.0'
+version          '0.16.1'
 supports         'centos'
 supports         'windows'
 


### PR DESCRIPTION
For services where we checked by checkids but not all checks, we had a
nil ref error:
NoMethodError: undefined method `include?' for nil:NilClass
/var/chef/cache/cookbooks/choregraphie/libraries/primitive_consul_health.rb:36:in `block (2 levels) in are_checks_passing?'
/var/chef/cache/cookbooks/choregraphie/libraries/primitive_consul_health.rb:35:in `select'
/var/chef/cache/cookbooks/choregraphie/libraries/primitive_consul_health.rb:35:in `block in are_checks_passing?'
/var/chef/cache/cookbooks/choregraphie/libraries/primitive_consul_health.rb:23:in `times'

This patch is fixing this

Change-Id: I0f1c02f4134c9acc07548a7a0c51f4acaec8b58c