### PR TITLE
Adapt to changes from ruby 2.7+

### DIFF
--- a/.github/workflows/criteo-cookbooks-ci.yml
+++ b/.github/workflows/criteo-cookbooks-ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rubocop --version
       - run: bundle exec rubocop
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: KITCHEN_LOCAL_YAML=.kitchen.docker.yml bundle exec kitchen verify ${{ matrix.instance }}
   supermarket:

--- a/libraries/dsl.rb
+++ b/libraries/dsl.rb
@@ -2,7 +2,7 @@ module Choregraphie
   module DSL
     # DSL helper
     def choregraphie(name)
-      Choregraphie.add(Choregraphie.new(name, &Proc.new))
+      Choregraphie.add(Choregraphie.new(name) { 'empty proc' })
     end
   end
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -60,6 +60,10 @@ execute 'name with a, in its name' do
   command 'uname'
 end
 
+def method_defined_outside_choregraphie_context
+  # we do nothing, just want to check we can be called
+end
+
 choregraphie 'execute' do
   on 'execute[converging]'
   on 'execute[not_converging]'
@@ -74,7 +78,10 @@ choregraphie 'execute' do
   on :weighted_resources
   on :converge_start
 
+  method_defined_outside_choregraphie_context
+
   before do |resource|
+    method_defined_outside_choregraphie_context
     filename = if resource.nil?
                  Chef::Log.warn('I am called before! for converge start')
                  'converge_start'


### PR DESCRIPTION
Starting with ruby 2.7, usage of Proc.new without a body is discouraged
(warning and then error).
This patch makes sure we are ready for this.

This part of the choregraphie code is a bit arcane for non-initiated and
I had trouble myself understanding the full picture 5 years after
writing it so here is my understanding.

Rationale:
- most people writing choregraphies are not heavy ruby users, quite
  often not even experienced chef users. They consider ruby/chef to be
  some kinf of magic
- specifically rules of bindings (what kind of definitions can be called
  within a block, depending of where it was defined) are not very clear.
  Usage of choregraphie dsl within chef dsl does not make any of this
  clearer
- a reasonable expectation as a user is to be able to call methods from
  within choregraphie (in the core block or in a before/after block)
  that were defined anywhere in the same file
- another reasonable expectation is to be able to call the same
  methods/variables inside and outside choregraphie block

Lines touched by this patch are doing exactly this: they store the
context in which choregraphie object was initialized and refer any
missing reference (method) to this context.

Fixes #62.

Change-Id: I5f4f9c8ba1dcf67e0e1bae1ba3fa17d29cea385a