### PR TITLE
Fix choregraphie dsl

### DIFF
--- a/libraries/dsl.rb
+++ b/libraries/dsl.rb
@@ -1,8 +1,8 @@
 module Choregraphie
   module DSL
     # DSL helper
-    def choregraphie(name)
-      Choregraphie.add(Choregraphie.new(name) { 'empty proc' })
+    def choregraphie(name, &block)
+      Choregraphie.add(Choregraphie.new(name, &block))
     end
   end
 end


### PR DESCRIPTION
During commit to support recent ruby we completely broke choregraphie
behavior (not calling the block passed to `choregraphie do ... end`).
This patch fixes it.

The reason we've not seen it is that serverspec validation was not
executed in kitchen 🤦. I'll fix it in a seperate commit.

Change-Id: I574faf8ec4a8cb8263ce4b2ec2c72460603d3590