### PR TITLE
Restore tests

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -12,7 +12,7 @@ provisioner:
   name: dokken
 
 verifier:
-  name: busser
+  name: inspec
 
 platforms:
 - name: centos-7

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -10,6 +10,7 @@ transport:
 
 provisioner:
   name: dokken
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -2,7 +2,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 14.7.17
+  chef_version: 17.9.26
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/.kitchen_suites.yml
+++ b/.kitchen_suites.yml
@@ -1,0 +1,3 @@
+  - name: default
+    run_list:
+      - recipe[test]

--- a/.kitchen_suites.yml
+++ b/.kitchen_suites.yml
@@ -1,3 +1,0 @@
-  - name: default
-    run_list:
-      - recipe[test]

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'kitchen-dokken'
 gem 'kitchen-vagrant'
 gem 'rake'
 gem 'serverspec'
+gem 'kitchen-inspec'
 
 gem 'kitchen-transport-speedy'
 group :ec2 do

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,14 @@
 source 'https://rubygems.org'
 
+gem 'chef', '>= 17.9.26'
+gem 'chefspec', '>= 9.3.1'
+
 gem 'berkshelf'
-gem 'chef'
-gem 'chefspec', '< 7.3.0'
-gem 'chef-zero-scheduled-task'
 gem 'foodcritic'
 gem 'kitchen-dokken'
-gem 'kitchen-vagrant'
+gem 'kitchen-inspec'
 gem 'rake'
 gem 'serverspec'
-gem 'kitchen-inspec'
-
-gem 'kitchen-transport-speedy'
-group :ec2 do
-  gem 'dotenv'
-  gem 'kitchen-ec2', git: 'https://github.com/criteo-forks/kitchen-ec2.git', branch: 'criteo'
-  gem 'test-kitchen'
-  gem 'winrm', '>= 1.6'
-  gem 'winrm-fs', '>= 0.3'
-end
 
 # Other gems should go after this comment
 gem 'diplomat', '>= 2.0.2'

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Usage of compat\_resource cookbook is highly discouraged as it modifies chef beh
 Choregraphies can be applied only on resources that support whyrun (currently chef default resources and resource/provider style).
 Custom resources (the whole resource defined in the resources/ directory) are not supported at the moment (see https://github.com/chef/chef/issues/4537 for a discussion).
 
+With chef >14, it's not possible anymore to hook on `log` resources.
+
 Available Primitives
 --------------------
 

--- a/libraries/dsl.rb
+++ b/libraries/dsl.rb
@@ -1,8 +1,8 @@
 module Choregraphie
   module DSL
     # DSL helper
-    def choregraphie(name)
-      Choregraphie.add(Choregraphie.new(name) { 'empty proc' })
+    def choregraphie(name, &block)
+      Choregraphie.add(Choregraphie.new(name, &block))
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Coordinates the application of changes induced by chef'
 long_description 'Installs/Configures choregraphie'
 issues_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :issues_url
 source_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :source_url
-version          '0.16.4'
+version          '0.16.5'
 supports         'centos'
 supports         'windows'
 chef_version     '>= 13.0.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,8 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!(allow: [
                                %r{127.0.0.1:\d+/(sandboxes|file_store|cookbooks|nodes|environments)},
                                /supermarket.chef.io/,
-                               /s3.amazonaws.com/
+                               /s3.amazonaws.com/,
+                               /fauxhai/
                              ])
 
 RSpec.configure do |config|

--- a/spec/unit/primitive_after_spec.rb
+++ b/spec/unit/primitive_after_spec.rb
@@ -17,6 +17,7 @@ describe Choregraphie::After do
 
     context 'when node has been installed long time ago' do
       before do
+        allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(/installed/).and_return(true)
       end
 
@@ -47,6 +48,7 @@ describe Choregraphie::After do
 
     context 'when node has just been installed' do
       before do
+        allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(/installed/).and_return(false)
       end
       context 'when a choregraphie is in progress' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -5,7 +5,7 @@ describe 'test::default' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '7.5.1804',
+        version: '7.8.2003',
       ) { ::Choregraphie::Choregraphie.clear }
       stub_command("test -f #{Dir.tmpdir}/not_converging.tmp").and_return(0)
       runner.converge(described_recipe)

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -38,8 +38,8 @@ test_simple_resource 'not_converging' do
   only_if { false }
 end
 
-log 'a_simple_log'
-log 'another_log'
+execute 'uname'
+execute 'uname -a'
 
 custom_resource 'my converging custom resource'
 
@@ -71,9 +71,7 @@ choregraphie 'execute' do
   on 'test_simple_resource[not_converging]'
   on 'custom_resource[my converging custom resource]'
   on 'custom_resource[my useless custom resource]'
-  on(/execute\[name with a,/)
-
-  on(/^log\[/)
+  on(/^execute/)
 
   on :weighted_resources
   on :converge_start
@@ -102,4 +100,4 @@ choregraphie 'execute' do
   end
 end
 
-log 'a_log_defined_after_choregraphie'
+execute 'echo a_command_defined_after_choregraphie'

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -4,9 +4,9 @@ dir = Dir.tmpdir
 %w[
   execute_converging
   test_simple_resource_converging
-  log_a_simple_log
-  log_another_log
-  log_a_log_defined_after_choregraphie
+  execute_uname
+  execute_uname_a
+  execute_echo_a_command_defined_after_choregraphie
   custom_resource_my_converging_custom_resource
   execute_whoami
 ].each do |path|

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'tmpdir'
 dir = Dir.tmpdir
 

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,6 +1,0 @@
-require 'serverspec'
-
-if /cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM
-  set :backend, :cmd
-  set :os, family: 'windows'
-end


### PR DESCRIPTION
This PR tests only on chef 17 and fixes tests for chef17.
We also make sure to restore testing by migrating to inspec (for some reason, serverspecs were not executed anymore).