### PR TITLE
Check several times maintenance status

### DIFF
--- a/spec/unit/primitive_consul_maintenance_spec.rb
+++ b/spec/unit/primitive_consul_maintenance_spec.rb
@@ -1,11 +1,12 @@
 require_relative '../../libraries/primitive_consul_maintenance'
 require 'diplomat'
+require 'webmock/rspec'
 
 describe Choregraphie::ConsulMaintenance do
   context 'When using consul_maintenance on node' do
     let(:choregraphie) do
       Choregraphie::Choregraphie.new('test') do
-        consul_maintenance reason: 'Testing', consul_token: 'foo'
+        consul_maintenance reason: 'Testing', consul_token: 'foo', check_interval: 0
       end
     end
 
@@ -40,7 +41,7 @@ describe Choregraphie::ConsulMaintenance do
     let(:service_id) { 'service_test' }
     let(:choregraphie) do
       Choregraphie::Choregraphie.new('test') do
-        consul_maintenance service_id: service_id, reason: 'Testing', consul_token: 'foo'
+        consul_maintenance service_id: service_id, reason: 'Testing', consul_token: 'foo', check_interval: 0
       end
     end
 


### PR DESCRIPTION
We've observed in rare cases that consul maintenance status was not
correct shortly after a restart (and for ~5s).
It seems to happen only on our setup and can be reproduced with:

```

set -o pipefail

while true; do
  curl -f -s localhost:8500/v1/agent/checks | jq ._node_maintenance.Notes -r > /tmp/res
  code=$?
  if [[ "$code" -eq 0 ]]; then
    if grep -q test /tmp/res; then
      # nothing
      echo -n .
    else
      echo "$(date) reproduced!"
    fi
  else
    echo "$(date) error in curl"
  fi

done
```

and doing a `sudo systemctl restart consul`

In front the difficult to reproduce, we won't open a ticket upstream for
now but critically need a safeguard since it can lead to incidents. For
instance an incident that really happen is the release of the
consul_lock primitve while keeping consul maintenance status enabled. A
whole cluster collapsed because of this.

Change-Id: Ia8c052d5f082e4ffcbe70360064feb0de17e00c9