### PR TITLE
Explicitly delegate keyword arguments

### DIFF
--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -46,8 +46,8 @@ module Choregraphie
       # instantiate the CheckFile primitive
       Primitive.all.each do |klass|
         instance_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{klass.primitive_name}(*args, &block)
-          primitive = ::#{klass}.new(*args, &block)
+        def #{klass.primitive_name}(*args, **kwargs, &block)
+          primitive = ::#{klass}.new(*args, **kwargs, &block)
           @primitives << primitive
           primitive.register(self)
         end
@@ -75,8 +75,8 @@ module Choregraphie
       instance_eval(&block)
     end
 
-    def method_missing(method, *args, &block) # rubocop:disable Style/MissingRespondToMissing
-      @self_before_instance_eval.send method, *args, &block
+    def method_missing(method, *args, **kwargs, &block) # rubocop:disable Style/MissingRespondToMissing
+      @self_before_instance_eval.send method, *args, **kwargs, &block
     end
 
     def cleanup_block_name(resource_name)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Coordinates the application of changes induced by chef'
 long_description 'Installs/Configures choregraphie'
 issues_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :issues_url
 source_url       'https://github.com/criteo-cookbooks/choregraphie' if respond_to? :source_url
-version          '0.16.6'
+version          '0.16.7'
 supports         'centos'
 supports         'windows'
 chef_version     '>= 13.0.0'


### PR DESCRIPTION
How keyword arguments are passed has changed with ruby v3, they now have to be explicitly delegated.