### PR TITLE
Make keyword arguments delegation compatible with ruby v3

### DIFF
--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -44,7 +44,7 @@ module Choregraphie
       # read all available primitives and make them available with a method
       # using their name. It allows to call `check_file '/tmp/titi'` to
       # instantiate the CheckFile primitive
-      delegated_args = RUBY_VERSION < '3' ? '*args, &block' : '*args, **kwargs, &block'
+      delegated_args = RUBY_VERSION.to_i < 3 ? '*args, &block' : '*args, **kwargs, &block'
       Primitive.all.each do |klass|
         instance_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{klass.primitive_name}(#{delegated_args})
@@ -76,7 +76,7 @@ module Choregraphie
       instance_eval(&block)
     end
 
-    if RUBY_VERSION < '3'
+    if RUBY_VERSION.to_i < 3
       def method_missing(method, *args, &block) # rubocop:disable Style/MissingRespondToMissing
         @self_before_instance_eval.send method, *args, &block
       end


### PR DESCRIPTION
How keyword arguments are passed has changed with ruby v3, they now have to be explicitly delegated, see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This patch add compatibility with Ruby v3 (which is embedded in recent versions of Chef), but also keep this cookbook functional with lower versions.