### PR TITLE
Return list of non-passing checks when consul_health_check primitive is failing

### DIFF
--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -129,7 +129,7 @@ module Choregraphie
       begin
         resource = run_context.resource_collection.find(resource_name)
       rescue Chef::Exceptions::ResourceNotFound
-        if ignore_missing_resource # rubocop:disable Style/GuardClause
+        if ignore_missing_resource
           # some resources are defined only when used
           # so we ignore them
           return

--- a/libraries/primitive_consul_health.rb
+++ b/libraries/primitive_consul_health.rb
@@ -51,7 +51,7 @@ module Choregraphie
 
         Chef::Log.warn "Some checks did not pass, will retry #{tries - try} more times"
       end
-      non_passing.map { |id, check| "#{check['ServiceName']}:#{id}" }
+      non_passing.map { |check| "#{check['ServiceName']}/#{check['CheckID']}" }
     end
 
     def register(choregraphie)

--- a/libraries/primitive_consul_maintenance.rb
+++ b/libraries/primitive_consul_maintenance.rb
@@ -28,7 +28,7 @@ module Choregraphie
       # we observed in very rare cases that maintenance status could be not up to date
       # for ~5s after a restart
       results = 3.times.map do
-        checks = Diplomat::Agent.checks()
+        checks = Diplomat::Agent.checks
         maint_status = checks.dig(@maintenance_key, 'Status')
         sleep(@options[:check_interval])
         maint_status == 'critical' && !checks.dig(@maintenance_key, 'Notes').nil?
@@ -40,7 +40,7 @@ module Choregraphie
 
     # @return [String, nil] reason of the maintenance, if any. Nil otherwise
     def maintenance_reason
-      checks = Diplomat::Agent.checks()
+      checks = Diplomat::Agent.checks
       checks.dig(@maintenance_key, 'Notes')
     end
 

--- a/spec/unit/primitive_consul_health_spec.rb
+++ b/spec/unit/primitive_consul_health_spec.rb
@@ -13,7 +13,7 @@ describe Choregraphie::ConsulHealthCheck do
     end
   end
   context 'when the healthcheck is not passing after n times' do
-    it 'must count service instances correctly' do
+    before do
       stub_request(:get, 'http://localhost:8500/v1/agent/checks')
         .to_return([
           {
@@ -27,8 +27,14 @@ describe Choregraphie::ConsulHealthCheck do
             }.to_json
           }
         ] * 3)
+    end
 
+    it 'must count service instances correctly' do
       expect { choregraphie.cleanup.each(&:call) }.to raise_error(/Failed to pass Consul checks/)
+    end
+
+    it 'mentions the failing checks' do
+      expect { choregraphie.cleanup.each(&:call) }.to raise_error(%r{Failed to pass Consul checks: service/service:ping})
     end
   end
 
@@ -102,6 +108,10 @@ describe Choregraphie::ConsulHealthCheck do
       end
       it 'fails' do
         expect { choregraphie.cleanup.each(&:call) }.to raise_error(/Failed to pass Consul checks/)
+      end
+
+      it 'mentions the failing checks' do
+        expect { choregraphie.cleanup.each(&:call) }.to raise_error(%r{Failed to pass Consul checks: my-service/service:ping3})
       end
     end
 

--- a/spec/unit/primitive_consul_health_spec.rb
+++ b/spec/unit/primitive_consul_health_spec.rb
@@ -21,6 +21,7 @@ describe Choregraphie::ConsulHealthCheck do
               'service:ping' => {
                 CheckID: 'service:ping',
                 Name: "Service 'ping' check",
+                ServiceName: 'service',
                 Status: 'critical'
               }
             }.to_json


### PR DESCRIPTION
Without this simple output, we have to rely on full Chef logs to identify the offenders.