### PR TITLE
Pass the user specified token to consul maintenance primitive

### DIFF
--- a/libraries/consul.rb
+++ b/libraries/consul.rb
@@ -1,4 +1,5 @@
 require_relative 'primitive'
+require 'ostruct' # This is a Diplomat dependency that they never specified ...
 
 # Common functions for Consul
 module Choregraphie

--- a/libraries/primitive_consul_maintenance.rb
+++ b/libraries/primitive_consul_maintenance.rb
@@ -28,7 +28,7 @@ module Choregraphie
       # we observed in very rare cases that maintenance status could be not up to date
       # for ~5s after a restart
       results = 3.times.map do
-        checks = Diplomat::Agent.checks
+        checks = Diplomat::Agent.checks(token: @options[:consul_token])
         maint_status = checks.dig(@maintenance_key, 'Status')
         sleep(@options[:check_interval])
         maint_status == 'critical' && !checks.dig(@maintenance_key, 'Notes').nil?
@@ -40,7 +40,7 @@ module Choregraphie
 
     # @return [String, nil] reason of the maintenance, if any. Nil otherwise
     def maintenance_reason
-      checks = Diplomat::Agent.checks
+      checks = Diplomat::Agent.checks(token: @options[:consul_token])
       checks.dig(@maintenance_key, 'Notes')
     end
 


### PR DESCRIPTION
Otherwise we use the "globally configured" token, that may change at any point in the chef run (because of diplomat model). Let's specify the token when requested. i.e. all checks calls.

If an incorrect token is used, it may lacks permission to detect the node/service maintenance.