### PR TITLE
Fix consul lib semaphore

### DIFF
--- a/libraries/consul.rb
+++ b/libraries/consul.rb
@@ -19,12 +19,12 @@ module Choregraphie
       end
     end
 
-    def self.update_backup_url(options)
+    def self.update_backup_url(consul_backup_url: nil)
       require 'diplomat'
-      return unless options[:consul_backup_url]
+      return if consul_backup_url.nil?
 
       Diplomat.configure do |config|
-        config.url = options[:consul_backup_url]
+        config.url = consul_backup_url
       end
     end
 

--- a/libraries/primitive_consul_lock.rb
+++ b/libraries/primitive_consul_lock.rb
@@ -51,7 +51,7 @@ module Choregraphie
 
     def semaphore
       # this object cannot be reused after enter/exit
-      semaphore_class.get_or_create(path, concurrency: concurrency, dc: @options[:datacenter], token: @options[:token])
+      semaphore_class.get_or_create(path, concurrency: concurrency, dc: @options[:datacenter], token: @options[:token], consul_backup_url: @options[:consul_backup_url])
     end
 
     def backoff(start_time, current_try)
@@ -129,7 +129,7 @@ module Choregraphie
         Chef::Log.info "Consul did not respond, wait #{retry_secs} seconds and retry to let it (re)start: #{e}"
         sleep retry_secs
         connection_failed_count += 1
-        ConsulCommon.update_backup_url(@options) if connection_failed_count == retry_total_attempts / 2
+        ConsulCommon.update_backup_url(kwargs[:consul_backup_url]) if connection_failed_count == retry_total_attempts / 2
         (retry_left -= 1).positive? ? retry : raise
       rescue Diplomat::KeyNotFound
         Chef::Log.info "Lock for #{path} did not exist, creating with value #{value}"

--- a/spec/unit/primitive_consul_lock_spec.rb
+++ b/spec/unit/primitive_consul_lock_spec.rb
@@ -62,7 +62,7 @@ describe Choregraphie::ConsulLock do
       lock = double('lock')
       expect(lock).to receive(:enter).with(name: 'my_node').and_return(true)
 
-      expect(Semaphore).to receive(:get_or_create).with('chef_lock/test', concurrency: 3, dc: nil, token: nil).and_return(lock)
+      expect(Semaphore).to receive(:get_or_create).with('chef_lock/test', concurrency: 3, dc: nil, token: nil, consul_backup_url: nil).and_return(lock)
 
       choregraphie_service.before.each(&:call)
     end


### PR DESCRIPTION
Previous patch didn't actually fix the root cause. Issue was that we were not in the same context, therefore @options param doesn't exist in class Semaphore.
Fix consists on instead passing the actual parameter instead of the whole options hash.