### PR TITLE
Check policy freshness after acquiring the consul lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/*
 .kitchen.local.yml
 
 .cookbook_version
+vendor/

--- a/libraries/choregraphie.rb
+++ b/libraries/choregraphie.rb
@@ -146,12 +146,12 @@ module Choregraphie
         resource.allowed_actions
                 .reject { |a| a == :nothing }
                 .each do |a|
-          provider = resource.provider_for_action(a)
-          next if provider.whyrun_supported?
+                  provider = resource.provider_for_action(a)
+                  next if provider.whyrun_supported?
 
-          Chef::Log.warn 'Resource providers must support whyrun in order to be used by choregraphie'
-          Chef::Log.warn 'If you are defining a custom resource see https://github.com/chef/chef/issues/4537 for a possible workaround'
-          raise "Provider for #{a} on #{resource.declared_key} must support whyrun"
+                  Chef::Log.warn 'Resource providers must support whyrun in order to be used by choregraphie'
+                  Chef::Log.warn 'If you are defining a custom resource see https://github.com/chef/chef/issues/4537 for a possible workaround'
+                  raise "Provider for #{a} on #{resource.declared_key} must support whyrun"
         end
       else
         Chef::Log.warn "#{resource_name} is not yet defined ?"

--- a/libraries/primitive_consul_lock.rb
+++ b/libraries/primitive_consul_lock.rb
@@ -6,6 +6,8 @@ require 'json'
 # This primitive is based on optimistic concurrency (using compare-and-swap) rather than consul sessions.
 # It allows to support the unavailability of the local consul agent (for reboot, reinstall, ...)
 module Choregraphie
+  class OutdatedPolicyError < RuntimeError; end
+
   class ConsulLock < Primitive
     def initialize(options = {})
       @options = Mash.new(options)
@@ -91,21 +93,66 @@ module Choregraphie
 
     def register(choregraphie)
       choregraphie.before do
-        wait_until(:enter) { semaphore.enter(name: @options[:id]) }
+        wait_until(:enter) { semaphore.enter(**lock_opts) }
+        begin
+          ensure_latest_policy!
+        rescue StandardError
+          release_lock
+          raise
+        end
       end
 
       choregraphie.finish do
-        # HACK: We can ignore failure there since it is only to release
-        # the lock. If there is a temporary failure, we can wait for the
-        # next run to release the lock without compromising safety.
-        # The reason we have to be a bit more relaxed here, is that all
-        # chef run including a choregraphie with this primitive try to
-        # release the lock at the end of a successful run
-        wait_until(:exit, max_failures: 5) { semaphore.exit(name: @options[:id]) }
+        release_lock
       end
     end
 
+    def lock_opts
+      { name: @options[:id] }
+    end
+
+    def release_lock
+      # HACK: We can ignore failure there since it is only to release
+      # the lock. If there is a temporary failure, we can wait for the
+      # next run to release the lock without compromising safety.
+      # The reason we have to be a bit more relaxed here, is that all
+      # chef run including a choregraphie with this primitive try to
+      # release the lock at the end of a successful run
+      wait_until(:exit, max_failures: 5) { semaphore.exit(**lock_opts) }
+    end
+
     private
+
+    # Fail-open on network errors only. HTTP errors (wrong path, auth, etc.)
+    # are re-raised so bugs in this check don't go unnoticed.
+    def ensure_latest_policy!
+      return unless @options[:ensure_latest_policy]
+
+      policy_name  = Chef::Config[:policy_name]
+      policy_group = Chef::Config[:policy_group]
+
+      return unless policy_name && policy_group
+
+      Chef::Log.info "Checking policy freshness for #{policy_name}/#{policy_group}"
+
+      require 'chef/server_api'
+      api = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
+      server_policy = api.get("policy_groups/#{policy_group}/policies/#{policy_name}")
+      server_revision = server_policy['revision_id']
+
+      current_revision = Chef.run_context.node.policy_revision
+
+      return if server_revision == current_revision
+
+      raise OutdatedPolicyError,
+            "Policy #{policy_name}/#{policy_group} has a newer revision on the server " \
+            "(running: #{current_revision}, server: #{server_revision}). " \
+            "Aborting run to pick up the new version."
+    rescue Net::HTTPExceptions, OutdatedPolicyError
+      raise
+    rescue StandardError => e
+      Chef::Log.warn "Failed to check policy freshness: #{e.class} - #{e.message}. Continuing anyway (fail-open)."
+    end
 
     def path
       @options[:path].sub(%r{^/}, '')

--- a/libraries/primitive_consul_rack_lock.rb
+++ b/libraries/primitive_consul_rack_lock.rb
@@ -15,24 +15,14 @@ module Choregraphie
       super
     end
 
-    def register(choregraphie)
-      choregraphie.before do
-        wait_until(:enter) { semaphore.enter(name: @options[:rack], server: @options[:id]) }
-      end
-
-      choregraphie.finish do
-        # HACK: We can ignore failure there since it is only to release
-        # the lock. If there is a temporary failure, we can wait for the
-        # next run to release the lock without compromising safety.
-        # The reason we have to be a bit more relaxed here, is that all
-        # chef run including a choregraphie with this primitive try to
-        # release the lock at the end of a successful run
-        wait_until(:exit, max_failures: 5) { semaphore.exit(name: @options[:rack], server: @options[:id]) }
-      end
-    end
-
     def semaphore_class
       SemaphoreByRack
+    end
+
+    private
+
+    def lock_opts
+      { name: @options[:rack], server: @options[:id] }
     end
   end
 

--- a/spec/unit/primitive_consul_lock_spec.rb
+++ b/spec/unit/primitive_consul_lock_spec.rb
@@ -67,4 +67,106 @@ describe Choregraphie::ConsulLock do
       choregraphie_service.before.each(&:call)
     end
   end
+
+  describe 'ensure_latest_policy' do
+    let(:choregraphie_policy) do
+      Choregraphie::Choregraphie.new('test_policy') do
+        consul_lock(path: '/chef_lock/test', id: 'my_node', concurrency: 1, backoff: 0, ensure_latest_policy: true)
+      end
+    end
+
+    before do
+      lock = double('lock')
+      allow(lock).to receive(:enter).with(name: 'my_node').and_return(true)
+      allow(Semaphore).to receive(:get_or_create).and_return(lock)
+
+      Chef::Config[:policy_name] = 'my_policy'
+      Chef::Config[:policy_group] = 'production'
+      Chef::Config[:chef_server_url] = 'https://chef.example.com'
+    end
+
+    it 'raises OutdatedPolicyError and releases the lock when policy is outdated' do
+      node = double('node', policy_revision: 'abc123')
+      events = double('events', register: nil)
+      allow(Chef).to receive(:run_context).and_return(double('run_context', node: node, events: events))
+
+      enter_lock = double('enter_lock')
+      allow(enter_lock).to receive(:enter).with(name: 'my_node').and_return(true)
+
+      exit_lock = double('exit_lock')
+      expect(exit_lock).to receive(:exit).with(name: 'my_node').and_return(true)
+
+      allow(Semaphore).to receive(:get_or_create).and_return(enter_lock, exit_lock)
+
+      api = double('api')
+      allow(Chef::ServerAPI).to receive(:new).and_return(api)
+      allow(api).to receive(:get).and_return({ 'revision_id' => 'def456' })
+
+      expect { choregraphie_policy.before.each(&:call) }
+        .to raise_error(Choregraphie::OutdatedPolicyError, /newer revision/)
+    end
+
+    it 'proceeds when policy is up to date' do
+      node = double('node', policy_revision: 'abc123')
+      events = double('events', register: nil)
+      allow(Chef).to receive(:run_context).and_return(double('run_context', node: node, events: events))
+
+      api = double('api')
+      allow(Chef::ServerAPI).to receive(:new).and_return(api)
+      allow(api).to receive(:get).and_return({ 'revision_id' => 'abc123' })
+
+      expect { choregraphie_policy.before.each(&:call) }.not_to raise_error
+    end
+
+    it 'skips the check when not explicitly enabled' do
+      choregraphie_default = Choregraphie::Choregraphie.new('test_default') do
+        consul_lock(path: '/chef_lock/test', id: 'my_node', concurrency: 1, backoff: 0)
+      end
+
+      lock = double('lock')
+      allow(lock).to receive(:enter).with(name: 'my_node').and_return(true)
+      allow(Semaphore).to receive(:get_or_create).and_return(lock)
+
+      expect(Chef::ServerAPI).not_to receive(:new)
+      choregraphie_default.before.each(&:call)
+    end
+
+    it 'skips the check when node does not use policyfiles' do
+      Chef::Config[:policy_name] = nil
+      Chef::Config[:policy_group] = nil
+
+      expect(Chef::ServerAPI).not_to receive(:new)
+      expect { choregraphie_policy.before.each(&:call) }.not_to raise_error
+    end
+
+    it 'continues on network error (fail-open)' do
+      api = double('api')
+      allow(Chef::ServerAPI).to receive(:new).and_return(api)
+      allow(api).to receive(:get).and_raise(Errno::ECONNREFUSED, 'connection refused')
+
+      expect(Chef::Log).to receive(:warn).with(/Failed to check policy freshness/)
+      expect { choregraphie_policy.before.each(&:call) }.not_to raise_error
+    end
+
+    it 'raises on HTTP errors and releases the lock' do
+      node = double('node', policy_revision: 'abc123')
+      events = double('events', register: nil)
+      allow(Chef).to receive(:run_context).and_return(double('run_context', node: node, events: events))
+
+      enter_lock = double('enter_lock')
+      allow(enter_lock).to receive(:enter).with(name: 'my_node').and_return(true)
+
+      exit_lock = double('exit_lock')
+      expect(exit_lock).to receive(:exit).with(name: 'my_node').and_return(true)
+
+      allow(Semaphore).to receive(:get_or_create).and_return(enter_lock, exit_lock)
+
+      api = double('api')
+      allow(Chef::ServerAPI).to receive(:new).and_return(api)
+      allow(api).to receive(:get).and_raise(Net::HTTPClientException.new('404 Not Found', double('response', code: '404')))
+
+      expect { choregraphie_policy.before.each(&:call) }
+        .to raise_error(Net::HTTPClientException)
+    end
+  end
 end


### PR DESCRIPTION
When a node acquires a choregraphie lock, it now verifies that no newer policy revision exists on the Chef server. If one does, the lock is released and the run aborts so the next converge picks up the latest cookbooks. This prevents nodes from being stuck converging an outdated (potentially broken) policy while waiting on the lock.

Opt-in via `ensure_latest_policy: true` (will consider opt-out when tested in real env)